### PR TITLE
Heroku への自動デプロイ機能追加

### DIFF
--- a/.github/workflows/deploy-to-heroku.yml
+++ b/.github/workflows/deploy-to-heroku.yml
@@ -1,0 +1,17 @@
+name: Deploy to heroku
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.8.8
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: "trainkun-api"
+          heroku_email: ${{secrets.HEROKU_EMAIL}}


### PR DESCRIPTION
## 概要
heroku自体に自動デプロイの機能はあるが、
GitHub action を利用したかったため作成した。

masterブランチに push された時点でデプロイを行う。

## その他（レビューで見てもらいたい点、不安な点、参考URLなど）
参考：https://github.com/marketplace/actions/deploy-to-heroku